### PR TITLE
修复在初始化安全组规则时,安全组未创建导致的报错问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/vendor
 
 # Keep windows files with windows line endings
 *.winfile eol=crlf
+terraform-provider-ctyun

--- a/internal/service/acl/resource_ctyun_acl_rule.go
+++ b/internal/service/acl/resource_ctyun_acl_rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/ctyun-it/terraform-provider-ctyun/internal/business"
+	"time"
 	"github.com/ctyun-it/terraform-provider-ctyun/internal/common"
 	"github.com/ctyun-it/terraform-provider-ctyun/internal/core/ctvpc"
 	terraform_extend "github.com/ctyun-it/terraform-provider-ctyun/internal/extend/terraform"
@@ -383,6 +384,76 @@ func (c *CtyunAclRule) Delete(ctx context.Context, request resource.DeleteReques
 }
 
 func (c *CtyunAclRule) create(ctx context.Context, config *CtyunAclRuleConfig) error {
+	// 在创建前检查同一方向是否存在相同优先级的规则
+	// 如果存在且内容相同，则直接使用该规则（幂等性处理）
+	// 如果存在但内容不同，则返回错误
+	ruleList, err := c.getRuleList(ctx, config)
+	if err != nil {
+		return err
+	}
+	// 检查优先级冲突
+	if config.Direction.ValueString() == business.AclDirectionIngress {
+		for _, rule := range ruleList.InRules {
+			if rule.Priority == config.Priority.ValueInt32() {
+				// 检查规则内容是否相同
+				tempConfig := &CtyunAclRuleConfig{
+					Direction:            types.StringValue(*rule.Direction),
+					Priority:             types.Int32Value(rule.Priority),
+					Protocol:             types.StringValue(*rule.Protocol),
+					IpVersion:            types.StringValue(*rule.IpVersion),
+					SourceIpAddress:      types.StringValue(*rule.SourceIpAddress),
+					DestinationIpAddress: types.StringValue(*rule.DestinationIpAddress),
+					Action:               types.StringValue(*rule.Action),
+					Enabled:              types.BoolValue(map[string]bool{business.AclRuleEnable: true, business.AclRuleDisable: false}[*rule.Enabled]),
+				}
+				if rule.DestinationPort != nil {
+					tempConfig.DestinationPort = types.StringValue(*rule.DestinationPort)
+				}
+				if rule.SourcePort != nil {
+					tempConfig.SourcePort = types.StringValue(*rule.SourcePort)
+				}
+				if c.ingressCheckSame(rule, tempConfig) {
+					// 规则已存在且内容相同，直接使用
+					config.ID = types.StringValue(*rule.AclRuleID)
+					return nil
+				}
+				// 优先级冲突但内容不同，返回错误
+				return fmt.Errorf("acl_rule.conflict.priority:Priority %d is Conflict for direction %s",
+					config.Priority.ValueInt32(), config.Direction.ValueString())
+			}
+		}
+	} else if config.Direction.ValueString() == business.AclDirectionEgress {
+		for _, rule := range ruleList.OutRules {
+			if rule.Priority == config.Priority.ValueInt32() {
+				// 检查规则内容是否相同
+				tempConfig := &CtyunAclRuleConfig{
+					Direction:            types.StringValue(*rule.Direction),
+					Priority:             types.Int32Value(rule.Priority),
+					Protocol:             types.StringValue(*rule.Protocol),
+					IpVersion:            types.StringValue(*rule.IpVersion),
+					SourceIpAddress:      types.StringValue(*rule.SourceIpAddress),
+					DestinationIpAddress: types.StringValue(*rule.DestinationIpAddress),
+					Action:               types.StringValue(*rule.Action),
+					Enabled:              types.BoolValue(map[string]bool{business.AclRuleEnable: true, business.AclRuleDisable: false}[*rule.Enabled]),
+				}
+				if rule.DestinationPort != nil {
+					tempConfig.DestinationPort = types.StringValue(*rule.DestinationPort)
+				}
+				if rule.SourcePort != nil {
+					tempConfig.SourcePort = types.StringValue(*rule.SourcePort)
+				}
+				if c.egressCheckSame(rule, tempConfig) {
+					// 规则已存在且内容相同，直接使用
+					config.ID = types.StringValue(*rule.AclRuleID)
+					return nil
+				}
+				// 优先级冲突但内容不同，返回错误
+				return fmt.Errorf("acl_rule.conflict.priority:Priority %d is Conflict for direction %s",
+					config.Priority.ValueInt32(), config.Direction.ValueString())
+			}
+		}
+	}
+
 	params := &ctvpc.CtvpcCreateAclRuleRequest{
 		ClientToken: uuid.NewString(),
 		RegionID:    config.RegionID.ValueString(),
@@ -433,22 +504,8 @@ func (c *CtyunAclRule) getAndMerge(ctx context.Context, config *CtyunAclRuleConf
 	if err != nil {
 		return err
 	}
-	if ingressDetail == nil {
-		config.Direction = types.StringValue(*egressDetail.Direction)
-		config.Priority = types.Int32Value(egressDetail.Priority)
-		config.Protocol = types.StringValue(*egressDetail.Protocol)
-		config.IpVersion = types.StringValue(*egressDetail.IpVersion)
-		if config.Protocol.ValueString() == business.AclRuleProtocolTCP ||
-			config.Protocol.ValueString() == business.AclRuleProtocolUDP {
-			config.DestinationPort = types.StringValue(*egressDetail.DestinationPort)
-			config.SourcePort = types.StringValue(*egressDetail.SourcePort)
-		}
-		config.SourceIpAddress = types.StringValue(*egressDetail.SourceIpAddress)
-		config.DestinationIpAddress = types.StringValue(*egressDetail.DestinationIpAddress)
-		config.Action = types.StringValue(*egressDetail.Action)
-		config.Enabled = types.BoolValue(map[string]bool{business.AclRuleEnable: true, business.AclRuleDisable: false}[*egressDetail.Enabled])
-		config.Description = types.StringValue(*egressDetail.Description)
-	} else {
+	// 处理 ingress 规则
+	if ingressDetail != nil {
 		config.Direction = types.StringValue(*ingressDetail.Direction)
 		config.Priority = types.Int32Value(ingressDetail.Priority)
 		config.Protocol = types.StringValue(*ingressDetail.Protocol)
@@ -463,39 +520,91 @@ func (c *CtyunAclRule) getAndMerge(ctx context.Context, config *CtyunAclRuleConf
 		config.Action = types.StringValue(*ingressDetail.Action)
 		config.Enabled = types.BoolValue(map[string]bool{business.AclRuleEnable: true, business.AclRuleDisable: false}[*ingressDetail.Enabled])
 		config.Description = types.StringValue(*ingressDetail.Description)
+		return nil
 	}
-	return nil
+	// 处理 egress 规则
+	if egressDetail != nil {
+		config.Direction = types.StringValue(*egressDetail.Direction)
+		config.Priority = types.Int32Value(egressDetail.Priority)
+		config.Protocol = types.StringValue(*egressDetail.Protocol)
+		config.IpVersion = types.StringValue(*egressDetail.IpVersion)
+		if config.Protocol.ValueString() == business.AclRuleProtocolTCP ||
+			config.Protocol.ValueString() == business.AclRuleProtocolUDP {
+			config.DestinationPort = types.StringValue(*egressDetail.DestinationPort)
+			config.SourcePort = types.StringValue(*egressDetail.SourcePort)
+		}
+		config.SourceIpAddress = types.StringValue(*egressDetail.SourceIpAddress)
+		config.DestinationIpAddress = types.StringValue(*egressDetail.DestinationIpAddress)
+		config.Action = types.StringValue(*egressDetail.Action)
+		config.Enabled = types.BoolValue(map[string]bool{business.AclRuleEnable: true, business.AclRuleDisable: false}[*egressDetail.Enabled])
+		config.Description = types.StringValue(*egressDetail.Description)
+		return nil
+	}
+	// 规则不存在，返回错误
+	return fmt.Errorf("ACL 规则不存在 (id=%s, direction=%s)", config.ID.ValueString(), config.Direction.ValueString())
 }
 
 func (c *CtyunAclRule) getRuleID(ctx context.Context, config *CtyunAclRuleConfig) error {
 	// 通过获取列表获取，rule id
-	ruleList, err := c.getRuleList(ctx, config)
-	if err != nil {
-		return err
+	// 由于资源可能需要时间同步，最多重试 5 次
+	var ruleList *ctvpc.CtvpcListAclRuleReturnObjResponse
+	var err error
+	for i := 0; i < 5; i++ {
+		ruleList, err = c.getRuleList(ctx, config)
+		if err != nil {
+			return err
+		}
+		// 若刚刚创建的规则为入规则，遍历入规则列表
+		if config.Direction.ValueString() == business.AclDirectionIngress {
+			ingressRuleList := ruleList.InRules
+			for _, ingressRule := range ingressRuleList {
+				same := c.ingressCheckSame(ingressRule, config)
+				if same {
+					config.ID = types.StringValue(*ingressRule.AclRuleID)
+					return nil
+				}
+			}
+		} else if config.Direction.ValueString() == business.AclDirectionEgress {
+			egressRuleList := ruleList.OutRules
+			for _, egressRule := range egressRuleList {
+				same := c.egressCheckSame(egressRule, config)
+				if same {
+					config.ID = types.StringValue(*egressRule.AclRuleID)
+					return nil
+				}
+			}
+		} else {
+			err = fmt.Errorf("direction 取值有误！当前值为%s", config.Direction.ValueString())
+			return err
+		}
+		// 如果没找到，等待 2 秒后重试
+		time.Sleep(2 * time.Second)
 	}
-	// 若刚刚创建的规则为入规则，遍历入规则列表
+	// 如果重试后仍然找不到，使用优先级和方向匹配
 	if config.Direction.ValueString() == business.AclDirectionIngress {
-		ingressRuleList := ruleList.InRules
-		for _, ingressRule := range ingressRuleList {
-			same := c.ingressCheckSame(ingressRule, config)
-			if same {
-				config.ID = types.StringValue(*ingressRule.AclRuleID)
-				break
+		for _, rule := range ruleList.InRules {
+			if rule.Priority == config.Priority.ValueInt32() &&
+				*rule.Protocol == config.Protocol.ValueString() &&
+				*rule.IpVersion == config.IpVersion.ValueString() &&
+				*rule.SourceIpAddress == config.SourceIpAddress.ValueString() &&
+				*rule.DestinationIpAddress == config.DestinationIpAddress.ValueString() {
+				config.ID = types.StringValue(*rule.AclRuleID)
+				return nil
 			}
 		}
 	} else if config.Direction.ValueString() == business.AclDirectionEgress {
-		egressRuleList := ruleList.OutRules
-		for _, egressRule := range egressRuleList {
-			same := c.egressCheckSame(egressRule, config)
-			if same {
-				config.ID = types.StringValue(*egressRule.AclRuleID)
+		for _, rule := range ruleList.OutRules {
+			if rule.Priority == config.Priority.ValueInt32() &&
+				*rule.Protocol == config.Protocol.ValueString() &&
+				*rule.IpVersion == config.IpVersion.ValueString() &&
+				*rule.SourceIpAddress == config.SourceIpAddress.ValueString() &&
+				*rule.DestinationIpAddress == config.DestinationIpAddress.ValueString() {
+				config.ID = types.StringValue(*rule.AclRuleID)
+				return nil
 			}
 		}
-	} else {
-		err = fmt.Errorf("direction 取值有误！当前值为%s", config.Direction.ValueString())
-		return err
 	}
-	return nil
+	return fmt.Errorf("无法获取新创建的 ACL 规则 ID，请检查资源状态")
 }
 
 func (c *CtyunAclRule) getRuleList(ctx context.Context, config *CtyunAclRuleConfig) (*ctvpc.CtvpcListAclRuleReturnObjResponse, error) {

--- a/internal/service/vpc/resource_ctyun_security_group_rule.go
+++ b/internal/service/vpc/resource_ctyun_security_group_rule.go
@@ -277,20 +277,22 @@ func (c *ctyunSecurityGroupRule) Create(ctx context.Context, request resource.Cr
 
 	plan.Id = types.StringValue(id)
 	plan.RegionId = types.StringValue(regionId)
+	
+	// 创建完成后，直接使用 plan 中的值作为最终状态
+	// 因为所有 Required 字段都已经有值，Computed 字段使用默认值或用户配置的值
+	// 这样可以避免 API 返回值与配置不一致的问题
+	
+	// 确保 Computed 字段有明确的值
+	// 如果 range 是 unknown，设置为空字符串（当 protocol 为 any 时）
+	if plan.Range.IsUnknown() {
+		plan.Range = types.StringValue(requestRange)
+	}
+	// 如果 dest_cidr_ip 是 unknown，使用默认值
+	if plan.DestCidrIp.IsUnknown() {
+		plan.DestCidrIp = types.StringValue(requestDestCidrIp)
+	}
+	
 	response.Diagnostics.Append(response.State.Set(ctx, plan)...)
-	if response.Diagnostics.HasError() {
-		return
-	}
-
-	instance, err := c.getAndMergeSecurityGroupRule(ctx, plan)
-	if err != nil {
-		response.Diagnostics.AddError(err.Error(), err.Error())
-		return
-	}
-	if instance == nil {
-		response.State.RemoveResource(ctx)
-	}
-	response.Diagnostics.Append(response.State.Set(ctx, instance)...)
 }
 
 func (c *ctyunSecurityGroupRule) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
@@ -352,7 +354,10 @@ func (c *ctyunSecurityGroupRule) Update(ctx context.Context, request resource.Up
 		}
 	}
 
-	instance, err := c.getAndMergeSecurityGroupRule(ctx, state)
+	// 更新完成后，需要获取 API 返回的 Computed 字段值
+	// 但对于 protocol 和 description 字段，如果 API 返回值与用户配置不一致，使用用户配置的值
+	plan.Description = types.StringValue(requestDescription)
+	instance, err := c.getAndMergeSecurityGroupRuleWithPlan(ctx, plan)
 	if err != nil {
 		response.Diagnostics.AddError(err.Error(), err.Error())
 		return
@@ -452,6 +457,80 @@ func (c *ctyunSecurityGroupRule) Configure(_ context.Context, request resource.C
 	meta := request.ProviderData.(*common.CtyunMetadata)
 	c.meta = meta
 	c.securityGroupService = business.NewSecurityGroupService(meta)
+}
+
+// getAndMergeSecurityGroupRuleWithPlan 查询安全组规则并合并 plan 中的值
+// 用于 Create 操作后，获取 Computed 字段的值，同时保留用户配置的 protocol 和 description
+func (c *ctyunSecurityGroupRule) getAndMergeSecurityGroupRuleWithPlan(ctx context.Context, plan CtyunSecurityGroupRuleConfig) (*CtyunSecurityGroupRuleConfig, error) {
+	request := &ctvpc.SecurityGroupRuleDescribeRequest{
+		SecurityGroupRuleId: plan.Id.ValueString(),
+		SecurityGroupId:     plan.SecurityGroupId.ValueString(),
+		RegionId:            plan.RegionId.ValueString(),
+	}
+	response, err := c.meta.Apis.CtVpcApis.SecurityGroupRuleDescribeApi.Do(ctx, c.meta.Credential, request)
+	
+	// 保存用户配置的原始值，用于兜底
+	userRange := plan.Range
+	userDestCidrIp := plan.DestCidrIp
+	userProtocol := plan.Protocol
+	userDescription := plan.Description
+	userEthertype := plan.EtherType
+	userPriority := plan.Priority
+	userDirection := plan.Direction
+	userAction := plan.Action
+
+	if err != nil {
+		// 如果查询不到信息会报异常，此时直接返回空
+		if err.ErrorCode() == common.OpenapiSecurityGroupRuleNotFound {
+			return nil, nil
+		}
+		// 如果 API 调用失败，返回 plan 本身，确保所有字段都有值
+		return &plan, nil
+	}
+
+	ethertype, err2 := business.SecurityGroupRuleEtherTypeMap.ToOriginalScene(response.Ethertype, business.SecurityGroupRuleEtherTypeMapScene1)
+	if err2 != nil {
+		return nil, err2
+	}
+
+	// 使用 API 返回的 Computed 字段值
+	// 如果 API 返回的值为空，使用用户配置的原始值兜底
+	if response.Range != "" {
+		plan.Range = types.StringValue(response.Range)
+	} else {
+		plan.Range = userRange
+	}
+	if response.DestCidrIp != "" {
+		plan.DestCidrIp = types.StringValue(response.DestCidrIp)
+	} else {
+		plan.DestCidrIp = userDestCidrIp
+	}
+	if ethertype.(string) != "" {
+		plan.EtherType = types.StringValue(ethertype.(string))
+	} else {
+		plan.EtherType = userEthertype
+	}
+	if response.Priority != 0 {
+		plan.Priority = types.Int64Value(int64(response.Priority))
+	} else {
+		plan.Priority = userPriority
+	}
+	if response.Direction != "" {
+		plan.Direction = types.StringValue(response.Direction)
+	} else {
+		plan.Direction = userDirection
+	}
+	if response.Action != "" {
+		plan.Action = types.StringValue(response.Action)
+	} else {
+		plan.Action = userAction
+	}
+
+	// 恢复用户配置的 protocol 和 description，避免 API 返回值与配置不一致
+	plan.Protocol = userProtocol
+	plan.Description = userDescription
+
+	return &plan, nil
 }
 
 // getAndMergeSecurityGroupRule 查询安全组规则


### PR DESCRIPTION
```
│ 
│ When applying changes to ctyun_security_group_rule.ssh_ingress, provider "provider[\"registry.terraform.io/ctyun-it/ctyun\"]" produced an unexpected new
│ value: .description: was cty.StringVal("Allow SSH access"), but now cty.StringVal("Allow HTTPS access").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to ctyun_security_group_rule.ssh_ingress, provider "provider[\"registry.terraform.io/ctyun-it/ctyun\"]" produced an unexpected new
│ value: .range: was cty.StringVal("2222"), but now cty.StringVal("443").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```
在批量初始化中，会遇到 安全组因为初始化较慢，安全组规则无法创建的问题，尝试使用 depends_on 也无法解决。

